### PR TITLE
Added subprotocol header.

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -117,6 +117,10 @@ class Factory {
         }
 
         // do protocol headers
+        if (count($subProtocols) > 0) {
+            $protocols = implode(',', $subProtocols);
+            if ($protocols != "") $request->setHeader('Sec-WebSocket-Protocol', $protocols);
+        }
 
         return $request;
     }


### PR DESCRIPTION
Hi Chris, The Websocket client appears to be working great to the extent that we are using it in the AutobahnPHP project. We did need to add the subprotocol header to it in order for our client to run with the python router.
