### PR TITLE
Added DNS Server Address in connect() function

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -1,5 +1,6 @@
 <?php
 namespace Ratchet\Client;
+use React\Dns\Resolver\Factory;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\Factory as ReactFactory;
 
@@ -8,12 +9,19 @@ use React\EventLoop\Factory as ReactFactory;
  * @param array              $subProtocols
  * @param array              $headers
  * @param LoopInterface|null $loop
+ * @param null               $dnsServerAddress
  * @return \React\Promise\PromiseInterface
  */
-function connect($url, array $subProtocols = [], $headers = [], LoopInterface $loop = null) {
+function connect($url, array $subProtocols = [], $headers = [], LoopInterface $loop = null, $dnsServerAddress = null) {
     $loop = $loop ?: ReactFactory::create();
 
-    $connector = new Connector($loop);
+    if (null !== $dnsServerAddress) {
+        $dnsFactory = new Factory();
+        $resolver = $dnsFactory->create($dnsServerAddress, $loop);
+        $connector = new Connector($loop, $resolver);
+    } else {
+        $connector = new Connector($loop);
+    }
     $connection = $connector($url, $subProtocols, $headers);
 
     register_shutdown_function(function() use ($loop) {


### PR DESCRIPTION
While using Ratchet with Docker I would like to address the Ratchet WebSocket Server with it's container name instead of using it's IP address (which may change whenever I restart the swarm).
Using the default resolver (8.8.8.8) means that I will not be able to address my containers by their name.

With this simple change one can specify the address of a custom DNS, in the case of Docker it's always 127.0.0.11.
It is fully compatible with the old usage.