### PR TITLE
Connection is not released after calling close()

### DIFF
--- a/src/WebSocket.php
+++ b/src/WebSocket.php
@@ -139,5 +139,6 @@ class WebSocket implements EventEmitterInterface {
         $closeFn($code, $reason);
 
         $this->_stream->end();
+        $this->_stream->close();
     }
 }


### PR DESCRIPTION
Watching the connection using netstat after calling close() doesn't release the connection but keeps it in ESTABLISHED state. Adding [$this->_stream->close();] fixes the issue.