### PR TITLE
Improve promise cancellation and close underlying socket connection

### DIFF
--- a/tests/unit/ConnectorTest.php
+++ b/tests/unit/ConnectorTest.php
@@ -4,6 +4,7 @@ use PHPUnit\Framework\TestCase;
 use Ratchet\Client\Connector;
 use React\EventLoop\Factory;
 use React\Promise\RejectedPromise;
+use React\Promise\Promise;
 
 class ConnectorTest extends TestCase
 {
@@ -35,5 +36,71 @@ class ConnectorTest extends TestCase
         $pawlConnector = new Connector($loop, $connector);
 
         $pawlConnector($uri);
+    }
+
+    public function testConnectorRejectsWhenUnderlyingSocketConnectorRejects()
+    {
+        $exception = new RuntimeException('Connection failed');
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->willReturn(\React\Promise\reject($exception));
+
+        $pawlConnector = new Connector($loop, $connector);
+
+        $promise = $pawlConnector('ws://localhost');
+
+        $actual = null;
+        $promise->then(null, function ($reason) use (&$actual) {
+            $actual = $reason;
+        });
+        $this->assertSame($exception, $actual);
+    }
+
+    public function testCancelConnectorShouldCancelUnderlyingSocketConnectorWhenSocketConnectionIsPending()
+    {
+        $promise = new Promise(function () { }, function () use (&$cancelled) {
+            ++$cancelled;
+        });
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->willReturn($promise);
+
+        $pawlConnector = new Connector($loop, $connector);
+
+        $promise = $pawlConnector('ws://localhost');
+
+        $this->assertNull($cancelled);
+        $promise->cancel();
+        $this->assertEquals(1, $cancelled);
+
+        $message = null;
+        $promise->then(null, function ($reason) use (&$message) {
+            $message = $reason->getMessage();
+        });
+        $this->assertEquals('Connection to ws://localhost cancelled during handshake', $message);
+    }
+
+    public function testCancelConnectorShouldCloseUnderlyingSocketConnectionWhenHandshakeIsPending()
+    {
+        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connection->expects($this->once())->method('close');
+
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->willReturn(\React\Promise\resolve($connection));
+
+        $pawlConnector = new Connector($loop, $connector);
+
+        $promise = $pawlConnector('ws://localhost');
+
+        $promise->cancel();
+
+        $message = null;
+        $promise->then(null, function ($reason) use (&$message) {
+            $message = $reason->getMessage();
+        });
+        $this->assertEquals('Connection to ws://localhost cancelled during handshake', $message);
     }
 }


### PR DESCRIPTION
This PR ensures that calling `cancel()` on a pending connection attempt will properly `cancel()` the underlying socket connection attempt or `close()` the underlying socket connection when the WebSocket handshake is pending.

This can also be used as a basis for connection timeouts in the future (e.g. https://github.com/friends-of-reactphp/mysql/pull/86) like this:

```php
$connecting = $pawlConnector('ws://localhost');

$loop->addTimer(10.0, function () use ($connecting) {
    $connecting->cancel();
});
```

Builds on top of https://github.com/clue/reactphp-socks/pull/82