### PR TITLE
use permessage-deflate

### DIFF
--- a/src/WebSocket.php
+++ b/src/WebSocket.php
@@ -2,6 +2,7 @@
 namespace Ratchet\Client;
 use Evenement\EventEmitterTrait;
 use Evenement\EventEmitterInterface;
+use Ratchet\RFC6455\Handshake\PermessageDeflateOptions;
 use React\Socket\ConnectionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -100,7 +101,11 @@ class WebSocket implements EventEmitterInterface {
             false,
             function() use ($reusableUAException) {
                 return $reusableUAException;
-            }
+            },
+            null,
+            null,
+            [$this->_stream, 'write'],
+            PermessageDeflateOptions::fromRequestOrResponse($response)[0]
         );
 
         $stream->on('data', [$streamer, 'onData']);


### PR DESCRIPTION
Without this deflated messages sent by server cannot be handled and the connection closes with exception _Ratchet detected an invalid reserve code_ (thrown by [ratchet/rfc6455/src/Messaging/MessageBuffer.php::270](https://github.com/ratchetphp/RFC6455/blob/master/src/Messaging/MessageBuffer.php#L270)) 

To improve on this I think that there needs to exist some nicer way of telling the Connector to send Sec-WebSocket-Extensions with permessage deflate options. For now I enable it by passing custom headers, but maybe a custom ClientNegotiator can be injected to the Connector?