### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os: linux
+arch:
+ - amd64
+ - ppc64le
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,17 @@ dist: trusty
 matrix:
   allow_failures:
     - php: hhvm
+  exclude:
+    - php: 5.4
+      arch: ppc64le
+    - php: 5.5
+      arch: ppc64le
+    - php: 5.6
+      arch: ppc64le
+    - php: 7.0
+      arch: ppc64le
+    - php: 7.3
+      arch: ppc64le
 
 before_script:
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "session.serialize_handler = php" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,23 @@
-os: linux
-arch:
- - amd64
- - ppc64le
 language: php
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - hhvm
-
-dist: trusty
-
-matrix:
+jobs:
+  include:
+    - php: "5.4"
+    - php: "5.5"
+    - php: "5.6"
+    - php: "7.0"
+    - php: "7.1"
+    - php: "7.2"
+    - php: "7.3"
+    - php: "hhvm"
+    - php: "7.1"
+      arch: ppc64le
+    - php: "7.2"
+      arch: ppc64le
   allow_failures:
     - php: hhvm
-  exclude:
-    - php: 5.4
-      arch: ppc64le
-    - php: 5.5
-      arch: ppc64le
-    - php: 5.6
-      arch: ppc64le
-    - php: 7.0
-      arch: ppc64le
-    - php: 7.3
-      arch: ppc64le
+
+dist: trusty
 
 before_script:
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "session.serialize_handler = php" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'


### PR DESCRIPTION
Add support for architecture ppc64le.  

Exclude php 5.4, 5.5, 5.6, 7.0, 7.3 for ppc64le as is it not available.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
