### PR TITLE
Document Psr\Http\Message\UriInterface as an allowed type for $url args

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -28,9 +28,9 @@ class Connector {
     }
 
     /**
-     * @param string $url
-     * @param array  $subProtocols
-     * @param array  $headers
+     * @param string|\Psr\Http\Message\UriInterface $url
+     * @param array                                 $subProtocols
+     * @param array                                 $headers
      * @return \React\Promise\PromiseInterface
      */
     public function __invoke($url, array $subProtocols = [], array $headers = []) {
@@ -116,9 +116,9 @@ class Connector {
     }
 
     /**
-     * @param string $url
-     * @param array  $subProtocols
-     * @param array  $headers
+     * @param string|\Psr\Http\Message\UriInterface $url
+     * @param array                                 $subProtocols
+     * @param array                                 $headers
      * @throws \InvalidArgumentException
      * @return \Psr\Http\Message\RequestInterface
      */

--- a/src/functions.php
+++ b/src/functions.php
@@ -5,10 +5,10 @@ use React\EventLoop\Factory as ReactFactory;
 use React\EventLoop\Timer\Timer;
 
 /**
- * @param string             $url
- * @param array              $subProtocols
- * @param array              $headers
- * @param LoopInterface|null $loop
+ * @param string|\Psr\Http\Message\UriInterface $url
+ * @param array                                 $subProtocols
+ * @param array                                 $headers
+ * @param LoopInterface|null                    $loop
  * @return \React\Promise\PromiseInterface<\Ratchet\Client\WebSocket>
  */
 function connect($url, array $subProtocols = [], $headers = [], LoopInterface $loop = null) {


### PR DESCRIPTION
In places where a URL is expected, the doc blocks state that strings are required, but there is no type enforcement at the moment.  Thanks to the implementation details of `GuzzleHttp\Psr7\uri_for()` (or its replacement method in their 2.0 release), any `Psr\Http\Message\UriInterface` is also acceptable in the Pawl API.  So, this PR updates the doc blocks to note that both strings and `Psr\Http\Message\UriInterface` objects are acceptable types when a URL is expected.