### PR TITLE
Allow use of guzzlehttp/psr7:^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
   , "require": {
         "php": ">=5.4"
       , "evenement/evenement": "^3.0 || ^2.0"
+      , "guzzlehttp/psr7": "^2.0 || ^1.7"
       , "ratchet/rfc6455": "^0.3"
       , "react/socket": "^1.9"
     }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.4"
       , "evenement/evenement": "^3.0 || ^2.0"
       , "guzzlehttp/psr7": "^2.0 || ^1.7"
-      , "ratchet/rfc6455": "^0.3"
+      , "ratchet/rfc6455": "^0.3.1"
       , "react/socket": "^1.9"
     }
   , "require-dev": {

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -85,10 +85,10 @@ class Connector {
 
                 $stream->removeListener('data', $headerParser);
 
-                $response = gPsr\parse_response($buffer);
+                $response = gPsr\Message::parseResponse($buffer);
 
                 if (!$this->_negotiator->validateResponse($request, $response)) {
-                    $futureWsConn->reject(new \DomainException(gPsr\str($response)));
+                    $futureWsConn->reject(new \DomainException(gPsr\Message::toString($response)));
                     $stream->close();
 
                     return;
@@ -110,7 +110,7 @@ class Connector {
             };
 
             $stream->on('data', $headerParser);
-            $stream->write(gPsr\str($request));
+            $stream->write(gPsr\Message::toString($request));
         }, array($futureWsConn, 'reject'));
 
         return $futureWsConn->promise();
@@ -124,7 +124,7 @@ class Connector {
      * @return \Psr\Http\Message\RequestInterface
      */
     protected function generateRequest($url, array $subProtocols, array $headers) {
-        $uri = gPsr\uri_for($url);
+        $uri = gPsr\Utils::uriFor($url);
 
         $scheme = $uri->getScheme();
 


### PR DESCRIPTION
This PR does two things:

1) Declares the dependency to `guzzlehttp/psr7` which was previously installed as a transient dependency
2) Updates the `Connector` class to avoid use of the deprecated functions from that package, this requires bumping the minimum supported `guzzlehttp/psr7` version up to 1.7 (when the replacements were introduced) and will allow use of the new 2.0 release