### PR TITLE
Simplify usage by supporting new default loop and new Socket API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ A more in-depth example using explicit interfaces: Requesting sub-protocols, and
 
 require __DIR__ . '/vendor/autoload.php';
 
-$loop = \React\EventLoop\Loop::get();
-$reactConnector = new \React\Socket\Connector($loop, [
+$reactConnector = new \React\Socket\Connector([
     'dns' => '8.8.8.8',
     'timeout' => 10
 ]);
+$loop = \React\EventLoop\Loop::get();
 $connector = new \Ratchet\Client\Connector($loop, $reactConnector);
 
 $connector('ws://127.0.0.1:9000', ['protocol1', 'subprotocol2'], ['Origin' => 'http://localhost'])

--- a/README.md
+++ b/README.md
@@ -10,24 +10,23 @@ An asynchronous WebSocket client in PHP
 
 #### Usage
 Pawl as a standalone app: Connect to an echo server, send a message, display output, close connection:
+
 ```php
 <?php
 
-    require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
-    \Ratchet\Client\connect('wss://echo.websocket.org:443')->then(function($conn) {
-        $conn->on('message', function($msg) use ($conn) {
-            echo "Received: {$msg}\n";
-            $conn->close();
-        });
-
-        $conn->send('Hello World!');
-    }, function ($e) {
-        echo "Could not connect: {$e->getMessage()}\n";
+\Ratchet\Client\connect('wss://echo.websocket.org:443')->then(function($conn) {
+    $conn->on('message', function($msg) use ($conn) {
+        echo "Received: {$msg}\n";
+        $conn->close();
     });
-```
 
----
+    $conn->send('Hello World!');
+}, function ($e) {
+    echo "Could not connect: {$e->getMessage()}\n";
+});
+```
 
 #### Classes
 
@@ -57,31 +56,29 @@ A more in-depth example using explicit interfaces: Requesting sub-protocols, and
 ```php
 <?php
 
-    require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
-    $loop = \React\EventLoop\Factory::create();
-    $reactConnector = new \React\Socket\Connector($loop, [
-        'dns' => '8.8.8.8',
-        'timeout' => 10
-    ]);
-    $connector = new \Ratchet\Client\Connector($loop, $reactConnector);
+$loop = \React\EventLoop\Loop::get();
+$reactConnector = new \React\Socket\Connector($loop, [
+    'dns' => '8.8.8.8',
+    'timeout' => 10
+]);
+$connector = new \Ratchet\Client\Connector($loop, $reactConnector);
 
-    $connector('ws://127.0.0.1:9000', ['protocol1', 'subprotocol2'], ['Origin' => 'http://localhost'])
-    ->then(function(\Ratchet\Client\WebSocket $conn) {
-        $conn->on('message', function(\Ratchet\RFC6455\Messaging\MessageInterface $msg) use ($conn) {
-            echo "Received: {$msg}\n";
-            $conn->close();
-        });
-
-        $conn->on('close', function($code = null, $reason = null) {
-            echo "Connection closed ({$code} - {$reason})\n";
-        });
-
-        $conn->send('Hello World!');
-    }, function(\Exception $e) use ($loop) {
-        echo "Could not connect: {$e->getMessage()}\n";
-        $loop->stop();
+$connector('ws://127.0.0.1:9000', ['protocol1', 'subprotocol2'], ['Origin' => 'http://localhost'])
+->then(function(\Ratchet\Client\WebSocket $conn) {
+    $conn->on('message', function(\Ratchet\RFC6455\Messaging\MessageInterface $msg) use ($conn) {
+        echo "Received: {$msg}\n";
+        $conn->close();
     });
 
-    $loop->run();
+    $conn->on('close', function($code = null, $reason = null) {
+        echo "Connection closed ({$code} - {$reason})\n";
+    });
+
+    $conn->send('Hello World!');
+}, function(\Exception $e) use ($loop) {
+    echo "Could not connect: {$e->getMessage()}\n";
+    $loop->stop();
+});
 ```

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,10 @@
     }
   , "require": {
         "php": ">=5.4"
-      , "react/socket": "^1.0 || ^0.8 || ^0.7"
       , "evenement/evenement": "^3.0 || ^2.0"
       , "ratchet/rfc6455": "^0.3"
+      , "react/event-loop": "^1.2"
+      , "react/socket": "^1.0 || ^0.8 || ^0.7"
     }
   , "require-dev": {
         "phpunit/phpunit": "~4.8"

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
         "php": ">=5.4"
       , "evenement/evenement": "^3.0 || ^2.0"
       , "ratchet/rfc6455": "^0.3"
-      , "react/event-loop": "^1.2"
-      , "react/socket": "^1.0 || ^0.8 || ^0.7"
+      , "react/socket": "^1.9"
     }
   , "require-dev": {
         "phpunit/phpunit": "~4.8"

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -20,9 +20,9 @@ class Connector {
         $this->_loop = $loop ?: Loop::get();
 
         if (null === $connector) {
-            $connector = new \React\Socket\Connector($this->_loop, [
+            $connector = new \React\Socket\Connector([
                 'timeout' => 20
-            ]);
+            ], $this->_loop);
         }
 
         $this->_connector  = $connector;

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -1,6 +1,7 @@
 <?php
 namespace Ratchet\Client;
 use Ratchet\RFC6455\Handshake\ClientNegotiator;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Socket\ConnectionInterface;
 use React\Socket\ConnectorInterface;
@@ -15,14 +16,15 @@ class Connector {
     protected $_secureConnector;
     protected $_negotiator;
 
-    public function __construct(LoopInterface $loop, ConnectorInterface $connector = null) {
+    public function __construct(LoopInterface $loop = null, ConnectorInterface $connector = null) {
+        $this->_loop = $loop ?: Loop::get();
+
         if (null === $connector) {
-            $connector = new \React\Socket\Connector($loop, [
+            $connector = new \React\Socket\Connector($this->_loop, [
                 'timeout' => 20
             ]);
         }
 
-        $this->_loop       = $loop;
         $this->_connector  = $connector;
         $this->_negotiator = new ClientNegotiator;
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,8 +1,6 @@
 <?php
 namespace Ratchet\Client;
 use React\EventLoop\LoopInterface;
-use React\EventLoop\Factory as ReactFactory;
-use React\EventLoop\Timer\Timer;
 
 /**
  * @param string             $url
@@ -12,22 +10,8 @@ use React\EventLoop\Timer\Timer;
  * @return \React\Promise\PromiseInterface<\Ratchet\Client\WebSocket>
  */
 function connect($url, array $subProtocols = [], $headers = [], LoopInterface $loop = null) {
-    $loop = $loop ?: ReactFactory::create();
-
     $connector = new Connector($loop);
     $connection = $connector($url, $subProtocols, $headers);
-
-    $runHasBeenCalled = false;
-
-    $loop->addTimer(Timer::MIN_INTERVAL, function () use (&$runHasBeenCalled) {
-        $runHasBeenCalled = true;
-    });
-
-    register_shutdown_function(function() use ($loop, &$runHasBeenCalled) {
-        if (!$runHasBeenCalled) {
-            $loop->run();
-        }
-    });
 
     return $connection;
 }

--- a/tests/autobahn/runner.php
+++ b/tests/autobahn/runner.php
@@ -6,10 +6,8 @@ use React\Promise\Deferred;
 
     define('AGENT', 'Pawl/0.3');
 
-    $loop = React\EventLoop\Factory::create();
-
-    $connFactory = function() use ($loop) {
-        $connector = new Ratchet\Client\Connector($loop);
+    $connFactory = function() {
+        $connector = new Ratchet\Client\Connector();
 
         return function($url) use ($connector) {
             return $connector('ws://127.0.0.1:9001' . $url);
@@ -29,14 +27,14 @@ use React\Promise\Deferred;
             return $futureNum->promise();
         }, function($e) {
             echo "Could not connect to test server: {$e->getMessage()}\n";
-        })->then(function($numOfCases) use ($connector, $loop) {
+        })->then(function($numOfCases) use ($connector) {
             echo "Running {$numOfCases} test cases\n\n";
 
             $allCases = new Deferred;
 
             $i = 0;
 
-            $runNextCase = function() use (&$runNextCase, &$i, $numOfCases, $allCases, $connector, $loop) {
+            $runNextCase = function() use (&$runNextCase, &$i, $numOfCases, $allCases, $connector) {
                 $i++;
 
                 if ($i > (int)$numOfCases->getPayload()) {
@@ -59,11 +57,11 @@ use React\Promise\Deferred;
             $runNextCase();
 
             return $allCases->promise();
-        })->then(function() use ($connector, $loop) {
-            $connector('/updateReports?agent=' . AGENT)->then(function(WebSocket $conn) use ($loop) {
+        })->then(function() use ($connector) {
+            $connector('/updateReports?agent=' . AGENT)->then(function(WebSocket $conn) {
                 echo "\nDone!\n";
-                $conn->on('close', [$loop, 'stop']);
+                $conn->on('close', function () {
+                    \React\EventLoop\Loop::stop();
+                });
             });
         });
-
-    $loop->run();

--- a/tests/unit/ConnectorTest.php
+++ b/tests/unit/ConnectorTest.php
@@ -2,12 +2,23 @@
 
 use PHPUnit\Framework\TestCase;
 use Ratchet\Client\Connector;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Promise\RejectedPromise;
 use React\Promise\Promise;
 
 class ConnectorTest extends TestCase
 {
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $factory = new Connector();
+
+        $ref = new \ReflectionProperty($factory, '_loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($factory);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function uriDataProvider() {
         return [
             ['ws://127.0.0.1', 'tcp://127.0.0.1:80'],
@@ -21,7 +32,7 @@ class ConnectorTest extends TestCase
      * @dataProvider uriDataProvider
      */
     public function testSecureConnectionUsesTlsScheme($uri, $expectedConnectorUri) {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
         $connector = $this->getMock('React\Socket\ConnectorInterface');
 

--- a/tests/unit/RequestUriTest.php
+++ b/tests/unit/RequestUriTest.php
@@ -29,9 +29,7 @@ class RequestUriTest extends TestCase {
      * @dataProvider uriDataProvider
      */
     function testGeneratedRequestUri($uri, $expectedRequestUri) {
-        $loop = Factory::create();
-
-        $connector = new Connector($loop);
+        $connector = new Connector();
 
         $generateRequest = self::getPrivateClassMethod('\Ratchet\Client\Connector', 'generateRequest');
         $request = $generateRequest->invokeArgs($connector, [$uri, [], []]);


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$connector = new \Ratchet\Client\Connector($loop);

// new (using default loop)
$connector = new \Ratchet\Client\Connector();
```

ReactPHP now implements the logic that previously lived inside the `connect()` function itself. This means that although this removes a bunch of code, this should not affect BC at all.

Builds on top of https://github.com/reactphp/event-loop/pull/226, https://github.com/reactphp/event-loop/pull/229, https://github.com/reactphp/event-loop/pull/232, https://github.com/reactphp/socket/pull/260, https://github.com/reactphp/socket/pull/264 and #124