### PR TITLE
 Run tests on PHPUnit 9 and PHP 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.0
           - 7.4
           - 7.3
           - 7.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           coverage: xdebug
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
+        if: ${{ matrix.php >= 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
       , "ratchet/rfc6455": "^0.3"
     }
   , "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8"
     }
   , "suggest": {
         "reactivex/rxphp": "~2.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-        forceCoversAnnotation="true"
         mapTestClassNameToCoveredClassName="true"
-        bootstrap="tests/bootstrap.php"
+        bootstrap="vendor/autoload.php"
         colors="true"
         backupGlobals="false"
         backupStaticAttributes="false"

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
         backupGlobals="false"
         backupStaticAttributes="false"
         bootstrap="vendor/autoload.php"
@@ -14,9 +14,9 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
+    <filter>
+        <whitelist>
             <directory>./src/</directory>
-        </include>
-    </coverage>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';

--- a/tests/unit/ConnectorTest.php
+++ b/tests/unit/ConnectorTest.php
@@ -23,7 +23,7 @@ class ConnectorTest extends TestCase
     public function testSecureConnectionUsesTlsScheme($uri, $expectedConnectorUri) {
         $loop = Factory::create();
 
-        $connector = $this->getMock('React\Socket\ConnectorInterface');
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
 
         $connector->expects($this->once())
             ->method('connect')


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.

For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.
This pull request builds on top of #124.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0 php vendor/bin/phpunit
PHPUnit 9.5.9 by Sebastian Bergmann and contributors.

...........                                                       11 / 11 (100%)

Time: 00:00.035, Memory: 6.00 MB

OK (11 tests, 17 assertions)
```