### PR TITLE
Run tests on PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.1
           - 8.0
           - 7.4
           - 7.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   PHPUnit:


### PR DESCRIPTION
Hi,

This PR enables testing on PHP 8.1 in the CI.

It also enables triggering the workflow manually.