### PR TITLE
Reduce composer package size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.github export-ignore
+tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+phpunit.xml.legacy export-ignore


### PR DESCRIPTION
This PR introduces a new `.gitattributes` file that ensures that only the files required for running the library and the LICENSE file end up in the vendors when installing the package using `--prefer-dist` (which is the default behaviour).

This results in a bundle at least two times smaller:

- With `.gitattributes`: 4.9KB
- Without it: 12KB

If this PR is accepted, I'll open similar ones for the other repositories.