### PR TITLE
Handle WS connection exception in Connector

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -74,6 +74,8 @@ class Connector {
             $stream->on('close', $earlyClose);
             $futureWsConn->promise()->then(function() use ($stream, $earlyClose) {
                 $stream->removeListener('close', $earlyClose);
+            }, function (\Exception $exception) use ($futureWsConn) {
+                $futureWsConn->reject($exception);
             });
 
             $buffer = '';


### PR DESCRIPTION
This commit introduces an exception handler into the Connector class. Now, when a WebSocket connection fails it captures the exception and explicitly rejects the promise, providing better error control and preventing silent failures.