### PR TITLE
PHP 8.4: Implicitly nullable parameters deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.4"
       , "evenement/evenement": "^3.0 || ^2.0"
       , "guzzlehttp/psr7": "^2.0 || ^1.7"
-      , "ratchet/rfc6455": "^0.3.1"
+      , "ratchet/rfc6455": "^0.4"
       , "react/socket": "^1.9"
     }
   , "require-dev": {

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -15,7 +15,7 @@ class Connector {
     protected $_connector;
     protected $_negotiator;
 
-    public function __construct(LoopInterface $loop = null, ConnectorInterface $connector = null) {
+    public function __construct(?LoopInterface $loop = null, ?ConnectorInterface $connector = null) {
         $this->_loop = $loop ?: Loop::get();
 
         if (null === $connector) {


### PR DESCRIPTION
Implicitly marking parameters as nullable is deprecated, the explicit nullable type must be used instead