### PR TITLE
Fix for 8.4 compatibility

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -9,7 +9,7 @@ use React\EventLoop\LoopInterface;
  * @param LoopInterface|null $loop
  * @return \React\Promise\PromiseInterface<\Ratchet\Client\WebSocket>
  */
-function connect($url, array $subProtocols = [], $headers = [], LoopInterface $loop = null) {
+function connect($url, array $subProtocols = [], $headers = [], ?LoopInterface $loop = null) {
     $connector = new Connector($loop);
     $connection = $connector($url, $subProtocols, $headers);
 


### PR DESCRIPTION
Deprecated: Ratchet\Client\connect(): Implicitly marking parameter $loop as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/ratchet/pawl/src/functions.php on line 12